### PR TITLE
Install version 3.2 from mongodb.org repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
+# Ambari
+.hash
+archive.zip
+# Various editors swap files
+*.sw?
+*~
 .idea
 *.iml

--- a/configuration/mongodb.xml
+++ b/configuration/mongodb.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
 
-<configuration>
+<configuration supports_final="true" supports_adding_forbidden="true">
     <property>
         <name>db_path</name>
         <value>/var/lib/mongo</value>
@@ -16,8 +16,6 @@
             Interface on which to listen, by default all interfaces.
             Set for example, 127.0.0.1 to switch to the local loopback interface only.
             Or set to a specific internal IP if known.
-            If you don't know the specific internal IP here, you should set mongodb_host instead to the hostname of the master server.
-            This will make client connections easier.
         </description>
     </property>
     <property>
@@ -26,14 +24,6 @@
         <description>
             Port on which mongod listens for incoming client connections.
             The Web Status page is always 1000 higher than this port number
-        </description>
-    </property>
-    <property>
-        <name>mongo_host</name>
-        <value>unknown</value>
-        <description>
-            You only need to set this if you haven't set bind_ip to a specific internal IP.
-            If you know either the internal IP or the mongodb host name in advance, this will make client connections easier.
         </description>
     </property>
 </configuration>

--- a/metainfo.xml
+++ b/metainfo.xml
@@ -6,9 +6,9 @@
             <name>MONGODB</name>
             <displayName>MongoDB</displayName>
             <comment>The intermediate database in your lambda stack</comment>
-            <version>2.6</version>
+            <version>3.2</version>
             <components>
-                    <component>
+                <component>
                     <name>MONGODB_MASTER</name>
                     <displayName>MongoDB Master</displayName>
                     <category>MASTER</category>
@@ -18,7 +18,7 @@
                         <timeout>6000</timeout>
                     </commandScript>
                 </component>
-                    <component>
+                <component>
                     <name>MONGODB_CLIENT</name>
                     <displayName>MongoDB Clients. Installs the client libraries and the kmongo script for ease of use.</displayName>
                     <category>CLIENT</category>
@@ -29,9 +29,9 @@
                     </commandScript>
                 </component>
             </components>
-           <osSpecifics>
+            <osSpecifics>
                 <osSpecific>
-                    <osFamily>any</osFamily>
+                    <osFamily>rhel5,rhel6,rhel7</osFamily>
                     <packages>
                         <package><name>glibc</name></package>
                     </packages>

--- a/metainfo.xml
+++ b/metainfo.xml
@@ -29,6 +29,7 @@
                     </commandScript>
                 </component>
             </components>
+
             <osSpecifics>
                 <osSpecific>
                     <osFamily>rhel5,rhel6,rhel7</osFamily>
@@ -37,6 +38,10 @@
                     </packages>
                 </osSpecific>
             </osSpecifics>
+
+            <configuration-dependencies>
+                <config-type>mongodb</config-type>
+            </configuration-dependencies>
         </service>
     </services>
 </metainfo>

--- a/package/scripts/mongo_master.py
+++ b/package/scripts/mongo_master.py
@@ -10,14 +10,14 @@ class MongoMaster(MongoBase):
         import params
         env.set_params(params)
         self.installMongo(env)
-        self.configure(env)
 
-    def configure(self,env):
+    def configure(self, env):
         import params
         env.set_params(params)
         self.configureMongo(env)
 
     def start(self, env):
+        self.configure(env)
         print "start mongodb"
         Execute('service mongod start > /dev/null ')
 

--- a/package/scripts/mongo_master.py
+++ b/package/scripts/mongo_master.py
@@ -19,15 +19,16 @@ class MongoMaster(MongoBase):
     def start(self, env):
         self.configure(env)
         print "start mongodb"
-        Execute('service mongod start > /dev/null ')
+        Execute('service mongod start')
 
     def stop(self, env):
         print "stop services.."
         Execute('service mongod stop')
 
     def restart(self, env):
+        self.configure(env)
         print "restart mongodb"
-        Execute('service mongod restart > /dev/null ')
+        Execute('service mongod restart')
 
     def status(self, env):
         print "checking status..."

--- a/package/scripts/params.py
+++ b/package/scripts/params.py
@@ -1,14 +1,9 @@
 from resource_management import *
-from resource_management.core.system import System
-import os
 
 config = Script.get_config()
 
 db_path = default('configurations/mongodb/db_path', '/var/lib/mongo')
 bind_ip = default('configurations/mongodb/bind_ip', '0.0.0.0')
-tcp_port = default('configurations/mongodb/tcp_port', '27017')
 # The web status page is always accessible at a port number that is 1000 greater than the port determined by tcp_port.
-mongo_host = default('configurations/mongodb/mongo_host', 'unknown')
-if mongo_host=="unknown":
-    if bind_ip not in ['0.0.0.0','127.0.0.1']:
-        mongo_host==bind_ip
+tcp_port = default('configurations/mongodb/tcp_port', '27017')
+mongo_host = default('/clusterHostInfo/mongodb_master_hosts', ['unknown'])[0]

--- a/package/templates/mongoclient.conf.j2
+++ b/package/templates/mongoclient.conf.j2
@@ -1,2 +1,2 @@
-mongo_host: {{mongo_host}}
-mongo_port: {{tcp_port}}
+mongo_host: {{ mongo_host }}
+mongo_port: {{ tcp_port }}

--- a/package/templates/mongod.conf.j2
+++ b/package/templates/mongod.conf.j2
@@ -1,76 +1,44 @@
 # mongod.conf
 
-#where to log
-logpath=/var/log/mongodb/mongod.log
+# for documentation of all options, see:
+#   http://docs.mongodb.org/manual/reference/configuration-options/
 
-logappend=true
+# where to write logging data.
+systemLog:
+  destination: file
+  logAppend: true
+  path: /var/log/mongodb/mongod.log
 
-# fork and run in background
-fork=true
+# Where and how to store data.
+storage:
+  dbPath: /var/lib/mongo
+  journal:
+    enabled: true
+#  engine:
+#  mmapv1:
+#  wiredTiger:
 
-#port=27017
+# how the process runs
+processManagement:
+  fork: true  # fork and run in background
+  pidFilePath: /var/run/mongodb/mongod.pid  # location of pidfile
 
-dbpath=/var/lib/mongo
+# network interfaces
+net:
+  port: 27017
+  bindIp: 127.0.0.1  # Listen to local interface only, comment to listen on all interfaces.
 
-# location of pidfile
-pidfilepath=/var/run/mongodb/mongod.pid
 
-# Listen to local interface only. Comment out to listen on all interfaces.
-# bind_ip=127.0.0.1
+#security:
 
-# Disables write-ahead journaling
-# nojournal=true
+#operationProfiling:
 
-# Enables periodic logging of CPU utilization and I/O wait
-#cpu=true
+#replication:
 
-# Turn on/off security.  Off is currently the default
-#noauth=true
-#auth=true
+#sharding:
 
-# Verbose logging output.
-#verbose=true
+## Enterprise-Only Options
 
-# Inspect all client data for validity on receipt (useful for
-# developing drivers)
-#objcheck=true
+#auditLog:
 
-# Enable db quota management
-#quota=true
-
-# Set oplogging level where n is
-#   0=off (default)
-#   1=W
-#   2=R
-#   3=both
-#   7=W+some reads
-#diaglog=0
-
-# Ignore query hints
-#nohints=true
-
-# Enable the HTTP interface (Defaults to port 28017).
-#httpinterface=true
-
-# Turns off server-side scripting.  This will result in greatly limited
-# functionality
-#noscripting=true
-
-# Turns off table scans.  Any query that would do a table scan fails.
-#notablescan=true
-
-# Disable data file preallocation.
-#noprealloc=true
-
-# Specify .ns file size for new databases.
-# nssize=<size>
-
-# Replication Options
-
-# in replicated mongo databases, specify the replica set name here
-#replSet=setname
-# maximum size in megabytes for replication operation log
-#oplogSize=1024
-# path to a key file storing authentication info for connections
-# between replica set members
-#keyFile=/path/to/keyfile
+#snmp:

--- a/package/templates/mongod.conf.j2
+++ b/package/templates/mongod.conf.j2
@@ -11,7 +11,7 @@ systemLog:
 
 # Where and how to store data.
 storage:
-  dbPath: /var/lib/mongo
+  dbPath: {{ db_path }}
   journal:
     enabled: true
 #  engine:
@@ -25,8 +25,8 @@ processManagement:
 
 # network interfaces
 net:
-  port: 27017
-  bindIp: 127.0.0.1  # Listen to local interface only, comment to listen on all interfaces.
+  port: {{ tcp_port }}
+  bindIp: {{ bind_ip }}  # Listen to local interface only, comment to listen on all interfaces.
 
 
 #security:

--- a/package/templates/mongodb.repo
+++ b/package/templates/mongodb.repo
@@ -1,5 +1,5 @@
-[mongodb]
+[mongodb-org]
 name=MongoDB Repository
-baseurl=http://downloads-distro.mongodb.org/repo/redhat/os/x86_64/
+baseurl=https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/3.2/$basearch/
+humanname=MongoDB Repository
 gpgcheck=0
-enabled=1

--- a/package/templates/mongodb.repo
+++ b/package/templates/mongodb.repo
@@ -1,5 +1,5 @@
 [mongodb-org]
 name=MongoDB Repository
 baseurl=https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/3.2/$basearch/
-humanname=MongoDB Repository
 gpgcheck=0
+enabled=1


### PR DESCRIPTION
Hi!

This PR allows to install latest stable MongoDB version 3.2.
- updated repo file
- updated mongod.conf.j2 template
- explicitly set that RHEL/CentOS distro family is supported

Tested on Ambari 2.2.1.1.

Thank you!
