### PR TITLE
Enable HTTPS for mongodb.org repository

### DIFF
--- a/package/files/mongodb-org.repo
+++ b/package/files/mongodb-org.repo
@@ -1,5 +1,5 @@
 [mongodb-org]
 name=MongoDB Repository
-baseurl=http://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/3.2/$basearch/
+baseurl=https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/3.2/$basearch/
 gpgcheck=0
 enabled=1


### PR DESCRIPTION
Makes secure connections to mongodb.org RPM repository.
