### PR TITLE
Allow to set Admin account credentials only during cluster installation

### DIFF
--- a/configuration/mongodb-admin.xml
+++ b/configuration/mongodb-admin.xml
@@ -29,6 +29,7 @@
     <value-attributes>
       <type>user</type>
       <empty-value-valid>true</empty-value-valid>
+      <editable-only-at-install>true</editable-only-at-install>
     </value-attributes>
   </property>
 
@@ -43,6 +44,7 @@
     <value-attributes>
       <type>password</type>
       <empty-value-valid>true</empty-value-valid>
+      <editable-only-at-install>true</editable-only-at-install>
     </value-attributes>
   </property>
 </configuration>


### PR DESCRIPTION
Changing Admin account credentials _after_ the MongoDB server installation will have no effect.
This PR disables `mongodb-admin` properties for already deployed component.
