### PR TITLE
Enable GPG verification for packages from mongodb-org repo

### DIFF
--- a/package/files/mongodb-org.repo
+++ b/package/files/mongodb-org.repo
@@ -1,5 +1,6 @@
-[mongodb-org]
+[mongodb-org-3.2]
 name=MongoDB Repository
 baseurl=https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/3.2/$basearch/
-gpgcheck=0
+gpgcheck=1
 enabled=1
+gpgkey=https://www.mongodb.org/static/pgp/server-3.2.asc


### PR DESCRIPTION
Another security improvement.
